### PR TITLE
implement starknet-rs support for block endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
         "@monaco-editor/react": "^4.6.0",
         "encoding": "^0.1.13",
         "monaco-editor": "^0.45.0",
-        "next": "13.5.4",
-        "react": "^18",
-        "react-dom": "^18",
+        "next": "^13.5.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "starknet": "^5.24.3"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "@monaco-editor/react": "^4.6.0",
     "encoding": "^0.1.13",
     "monaco-editor": "^0.45.0",
-    "next": "13.5.4",
-    "react": "^18",
-    "react-dom": "^18",
+    "next": "^13.5.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "starknet": "^5.24.3"
   },
   "devDependencies": {

--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -24,6 +24,7 @@ const block_id = {
   ],
 };
 
+
 const contract_address = {
   placeholder:
     "0x124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49",
@@ -161,6 +162,7 @@ const DEPLOY_ACCOUNT_TXN_V1 = {
 
 const BROADCASTED_DEPLOY_ACCOUNT_TXN = DEPLOY_ACCOUNT_TXN_V1;
 
+
 const ReadMethods = [
   // Returns the version of the Starknet JSON-RPC specification being used
   {
@@ -210,7 +212,36 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: ``,
+    starknetRs: `
+    use starknet::{
+      core::types::{BlockId, BlockTag,MaybePendingBlockWithTxHashes},
+      providers::{
+          jsonrpc::{HttpTransport, JsonRpcClient},
+          Provider, Url,
+      },
+  };
+  
+ 
+  #[tokio::main]
+  async fn main() {
+      
+      let provider = JsonRpcClient::new(HttpTransport::new(
+          Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+      ));
+      
+      let result = provider.get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest)).await;
+
+      match result {
+          Ok(block) => {
+              println!("{block:#?}");
+          }
+          Err(err) => {
+              eprintln!("Error: {err}");
+          }
+      }
+      
+  }
+  `,
   },
 
   // Get block information with full transactions given the block id
@@ -224,7 +255,34 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: ``,
+    starknetRs: `
+    use starknet::{
+      core::types::{BlockId, BlockTag,MaybePendingBlockWithTxs},
+      providers::{
+          jsonrpc::{HttpTransport, JsonRpcClient},
+          Provider, Url,
+      },
+  };
+  
+  #[tokio::main]
+  async fn main() {
+      let provider = JsonRpcClient::new(HttpTransport::new(
+          Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+      ));
+  
+      let result = provider.get_block_with_txs(BlockId::Tag(BlockTag::Latest)).await;
+      
+      match result {
+          Ok(block) => {
+              println!("{block:#?}");
+          }
+          Err(err) => {
+              eprintln!("Error: {err}");
+          }
+      
+      }
+  }
+  `,
   },
 
   // Get the information about the result of executing the requested block
@@ -238,7 +296,31 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: ``,
+    starknetRs: `
+      use starknet::{
+      core::types::{BlockId, BlockTag,MaybePendingStateUpdate},
+      providers::{
+      jsonrpc::{HttpTransport, JsonRpcClient},
+      Provider, Url,
+      }, 
+     };
+  
+  #[tokio::main]
+  async fn main() {
+      let provider = JsonRpcClient::new(HttpTransport::new(
+          Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+      ));
+  
+      let result = provider.get_state_update(BlockId::Tag(BlockTag::Latest)).await;
+      match result {
+          Ok(state_update) => {
+              println!("{state_update:#?}");
+          }
+          Err(err) => {
+              eprintln!("Error: {err}");
+          }
+      }
+    }`,
   },
 
   // Get the value of the storage at the given address and key
@@ -258,7 +340,32 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: ``,
+    starknetRs: `
+    use starknet::{
+      core::types::FieldElement,
+      providers::{
+      jsonrpc::{HttpTransport, JsonRpcClient},
+      Provider, Url,
+  },
+  };
+  
+  #[tokio::main]
+  async fn main() {
+      let provider = JsonRpcClient::new(HttpTransport::new(
+          Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+      ));
+  
+      let result = provider.get_storage_at(felt!("0x124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49"),felt!("0x1001e85047571380eed1d7e1cc5a9af6a707b3d65789bb1702c7d680e5e87e"),BlockId::Tag(BlockTag::Latest)).await;
+      match result {
+          Ok(storage) => {
+              println!("{storage:#?}");
+          }
+          Err(err) => {
+              eprintln!("Error: {err}");
+          }
+      }
+  }
+    `,
   },
 
   // Gets the transaction status (possibly reflecting that the tx is still in the mempool, or dropped from it)
@@ -455,7 +562,30 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: ``,
+    starknetRs: `
+    use starknet::providers::{
+      jsonrpc::{HttpTransport, JsonRpcClient},
+      Provider, Url,
+    };
+  
+   #[tokio::main]
+   async fn main() {
+      let provider = JsonRpcClient::new(HttpTransport::new(
+          Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+      ));
+  
+      let result = provider.block_number().await;
+      
+      match result {
+          Ok(block_number) => {
+              println!("{block_number:#?}");
+          }
+          Err(err) => {
+              eprintln!("Error: {err}");
+          }
+      }
+   }
+    `,
   },
 
   // Get the most recent accepted block hash and number
@@ -464,10 +594,36 @@ const ReadMethods = [
     params: [],
     starknetJs: `${STARKNET_JS_PREFIX}provider.getBlockLatestAccepted().then(blockHashAndNumber => {
     console.log(blockHashAndNumber);
-});
+    });
     `,
     starknetGo: ``,
-    starknetRs: ``,
+    starknetRs: `
+    use starknet::{
+    core::types::{BlockHashAndNumber}
+    providers::{
+      jsonrpc::{HttpTransport, JsonRpcClient},
+      Provider, Url,
+      },
+    };
+  
+  #[tokio::main]
+  async fn main() {
+      let provider = JsonRpcClient::new(HttpTransport::new(
+          Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+      ));
+  
+      let result = provider.block_hash_and_number().await;
+      match result {
+          Ok(block_hash_and_number) => {
+              println!("{block_hash_and_number:#?}");
+          }
+          Err(err) => {
+              eprintln!("Error: {err}");
+          }
+      
+      }
+    }
+  `,
   },
 
   // Return the currently configured StarkNet chain id
@@ -622,6 +778,7 @@ const TraceMethods = [
     starknetRs: ``,
   },
 ];
+
 
 export const Methods = [...ReadMethods, ...TraceMethods, ...WriteMethods];
 export const comingSoon = [

--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -212,9 +212,8 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: `
-    use starknet::{
-      core::types::{BlockId, BlockTag,MaybePendingBlockWithTxHashes},
+    starknetRs: `use starknet::{
+      core::types::{BlockId, BlockTag},
       providers::{
           jsonrpc::{HttpTransport, JsonRpcClient},
           Provider, Url,
@@ -255,12 +254,11 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: `
-    use starknet::{
-      core::types::{BlockId, BlockTag,MaybePendingBlockWithTxs},
+    starknetRs: `use starknet::{
+      core::types::{BlockId, BlockTag},
       providers::{
-          jsonrpc::{HttpTransport, JsonRpcClient},
-          Provider, Url,
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Provider, Url,
       },
   };
   
@@ -296,12 +294,11 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: `
-      use starknet::{
+    starknetRs: `use starknet::{
       core::types::{BlockId, BlockTag,MaybePendingStateUpdate},
       providers::{
-      jsonrpc::{HttpTransport, JsonRpcClient},
-      Provider, Url,
+       jsonrpc::{HttpTransport, JsonRpcClient},
+       Provider, Url,
       }, 
      };
   
@@ -340,13 +337,13 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: `
-    use starknet::{
-      core::types::FieldElement,
+    starknetRs: `use starknet::{
+      core::types::{BlockId,BlockTag},
+      macros::felt,
       providers::{
-      jsonrpc::{HttpTransport, JsonRpcClient},
-      Provider, Url,
-  },
+       jsonrpc::{HttpTransport, JsonRpcClient},
+       Provider, Url,
+    },
   };
   
   #[tokio::main]
@@ -562,8 +559,7 @@ const ReadMethods = [
 });
     `,
     starknetGo: ``,
-    starknetRs: `
-    use starknet::providers::{
+    starknetRs: `use starknet::providers::{
       jsonrpc::{HttpTransport, JsonRpcClient},
       Provider, Url,
     };
@@ -597,13 +593,9 @@ const ReadMethods = [
     });
     `,
     starknetGo: ``,
-    starknetRs: `
-    use starknet::{
-    core::types::{BlockHashAndNumber}
-    providers::{
+    starknetRs: `use starknet::providers::{
       jsonrpc::{HttpTransport, JsonRpcClient},
       Provider, Url,
-      },
     };
   
   #[tokio::main]

--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -297,8 +297,8 @@ const ReadMethods = [
     starknetRs: `use starknet::{
       core::types::{BlockId, BlockTag,MaybePendingStateUpdate},
       providers::{
-       jsonrpc::{HttpTransport, JsonRpcClient},
-       Provider, Url,
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Provider, Url,
       }, 
      };
   
@@ -341,8 +341,8 @@ const ReadMethods = [
       core::types::{BlockId,BlockTag},
       macros::felt,
       providers::{
-       jsonrpc::{HttpTransport, JsonRpcClient},
-       Provider, Url,
+        jsonrpc::{HttpTransport, JsonRpcClient},
+        Provider, Url,
     },
   };
   

--- a/src/components/Builder.tsx
+++ b/src/components/Builder.tsx
@@ -21,6 +21,7 @@ import {
   isUrlFromNethermindDomain,
   extractRpcUrl,
   extractNodeUrl,
+  capitalize,
 } from "./utils";
 
 const formatName = (name: string) => {
@@ -111,7 +112,11 @@ const Builder = () => {
           ? rawRequest
           : requestTab == "curl"
           ? curlRequest
-          : starknetJs
+          : requestTab === "starknetJs"
+          ? starknetJs
+          : requestTab === "starknetGo"
+          ? starknetGo
+          : starknetRs
       );
     } else {
       navigator.clipboard.writeText(response);
@@ -319,7 +324,63 @@ const Builder = () => {
     const updateStarknetRsParams = (currentParamsObj: {
       [key: string]: any;
     }) => {
-      return method.starknetRs; // TODO: Implement this
+      const regexPattern = /provider\s*\.(\w+)\((.*)\s*\.await;/;
+      const codeSnippet = method.starknetRs;
+
+      const updatedCode = codeSnippet.replace(
+        regexPattern,
+        (match, methodName, params) => {
+          const values = Object.entries(currentParamsObj).flatMap(
+            ([key, value]) => {
+              if (key === "block_id") {
+                if (
+                  typeof value === "string" &&
+                  ["latest", "pending"].includes(value)
+                ) {
+                  return `BlockId::Tag(BlockTag::${capitalize(value)})`;
+                } else if (typeof value === "object") {
+                  if (value.block_hash !== undefined) {
+                    const { block_hash: blockHash } = value as {
+                      block_hash: string;
+                    };
+                    return `BlockId::Hash(felt!("${blockHash}"))`;
+                  } else if (value.block_number !== undefined) {
+                    const { block_number: blockNumber } = value as {
+                      block_number: number;
+                    };
+                    return `BlockId::Number(${blockNumber})`;
+                  }
+                }
+              } else if (typeof value === "object" && !Array.isArray(value)) {
+                // If value is an object, return its stringified values
+                return Object.values(value).map((val) => {
+                  if (typeof val === "string") {
+                    if (val.startsWith("0x")) {
+                      return `felt!("${val}")`;
+                    }
+                    return `"${val}"`;
+                  }
+                  return val;
+                });
+              } else if (typeof value === "string") {
+                if (value.startsWith("0x")) {
+                  return `felt!("${value}")`;
+                }
+                // If value is a string, return it with quotes
+                return `"${value}"`;
+              }
+              return value; // Return other types (like numbers) as is
+            }
+          );
+
+          let stringifiedParams = values.join(", ");
+          return `provider
+    .${methodName}(${stringifiedParams})
+    .await;`;
+        }
+      );
+
+      return updatedCode;
     };
 
     const updateMethod = (methodName: string, latestParamsArray: any) => {
@@ -924,6 +985,23 @@ const Builder = () => {
                     language="go"
                     theme="vs-dark"
                     value={starknetGo}
+                    options={{
+                      readOnly: true,
+                      fontSize: 14,
+                      minimap: { enabled: false },
+                      scrollBeyondLastLine: false,
+                      scrollbar: {
+                        horizontal: "hidden",
+                      },
+                    }}
+                  />
+                )}
+                   {requestTab == "starknetRs" && (
+                  <Editor
+                    height="50vh"
+                    language="rust"
+                    theme="vs-dark"
+                    value={starknetRs}
                     options={{
                       readOnly: true,
                       fontSize: 14,

--- a/src/components/constant.ts
+++ b/src/components/constant.ts
@@ -38,7 +38,30 @@ func main() {
 
 	fmt.Println("SpecVersion:", specVersion)
 }`;
-export const DEFAULT_STARKNET_RS_REQUEST = ``;
+export const DEFAULT_STARKNET_RS_REQUEST = `use starknet::{
+	providers::{
+	  jsonrpc::{HttpTransport, JsonRpcClient},
+	  Provider, Url,
+	},
+  };
+  #[tokio::main]
+  async fn main() {
+	let provider = JsonRpcClient::new(HttpTransport::new(
+	  Url::parse("https://free-rpc.nethermind.io/mainnet-juno/").unwrap(),
+	));
+	let result = provider.
+	  spec_version()
+	  .await;
+	match result {
+	  Ok(spec_version) => {
+		println!("{spec_version:#?}");
+	  }
+	  Err(err) => {
+		eprintln!("Error: {err}");
+	  }
+	}
+  }
+  `;
 export const CURL_HEADER = `--header 'Content-Type: application/json' \\`;
 export const DEFAULT_CURL_REQUEST = `curl --location 'https://free-rpc.nethermind.io/mainnet-juno/' \\
 ${CURL_HEADER}

--- a/src/components/constant.ts
+++ b/src/components/constant.ts
@@ -44,6 +44,7 @@ export const DEFAULT_STARKNET_RS_REQUEST = `use starknet::{
 	  Provider, Url,
 	},
   };
+  
   #[tokio::main]
   async fn main() {
 	let provider = JsonRpcClient::new(HttpTransport::new(

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -36,3 +36,6 @@ export const extractNodeUrl = (starknetJsCode: string) => {
     return null;
   }
 };
+
+export const capitalize = (str: string) =>
+  `${str.charAt(0).toUpperCase()}${str.slice(1)}`;


### PR DESCRIPTION
This PR implements the ```starknet-rs``` support for block endpoints. 
Fixes #14 