### PR TITLE
Implemented starknet.go support for write endpoints

### DIFF
--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -6,6 +6,22 @@ const provider = new RpcProvider({
 })
 
 `;
+const STARKNET_GO_PREFIX = `package main
+import (
+  "context"
+  "fmt"
+  "log"
+  "github.com/NethermindEth/starknet.go/rpc"
+)
+    
+func main() {
+  rpcUrl := "https://free-rpc.nethermind.io/mainnet-juno/"
+  client, err := rpc.NewClient(rpcUrl)
+  if err != nil {
+    log.Fatal(err)
+  }
+  provider := rpc.NewProvider(client)
+`;
 
 const block_id = {
   placeholder: "latest",
@@ -551,7 +567,13 @@ const WriteMethods = [
       invoke_transaction: BROADCASTED_INVOKE_TXN,
     },
     starknetJs: ``,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}
+  response, err := provider.AddInvokeTransaction(context.Background())
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Println("Response:", response)
+}`,
     starknetRs: ``,
   },
 
@@ -571,7 +593,13 @@ const WriteMethods = [
       deploy_account_transaction: BROADCASTED_DEPLOY_ACCOUNT_TXN,
     },
     starknetJs: ``,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}
+  response, err := provider.AddDeployAccountTransaction(context.Background())
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Println("Response:", response)
+}`,
     starknetRs: ``,
   },
 ];

--- a/src/components/Builder.tsx
+++ b/src/components/Builder.tsx
@@ -111,7 +111,11 @@ const Builder = () => {
           ? rawRequest
           : requestTab == "curl"
           ? curlRequest
-          : starknetJs
+          : requestTab == "starknetJs"
+          ? starknetJs
+          : requestTab == "starknetGo"
+          ? starknetGo
+          : starknetRs
       );
     } else {
       navigator.clipboard.writeText(response);
@@ -313,7 +317,34 @@ const Builder = () => {
     const updateStarknetGoParams = (currentParamsObj: {
       [key: string]: any;
     }) => {
-      return method.starknetGo; // TODO: Implement this
+      const regexPattern = /provider\.(\w+)\(([^)]*)\)/;
+      const codeSnippet = method.starknetGo;
+
+      const updatedCode = codeSnippet.replace(
+        regexPattern,
+        (match, methodName, params) => {
+          const values = Object.entries(currentParamsObj).flatMap(
+            ([key, value]) => {
+              // if (key === "")
+              if (typeof value === "object" && !Array.isArray(value)) {
+                // If value is an object, return its stringified values
+                return Object.values(value).map((val) =>
+                  typeof val === "string" ? `"${val}"` : val
+                );
+              } else if (typeof value === "string") {
+                // If value is a string, return it with quotes
+                return `"${value}"`;
+              }
+              return value; // Return other types (like numbers) as is
+            }
+          );
+
+          let stringifiedParams = values.join(", ");
+          return `provider.${methodName}(${stringifiedParams})`;
+        }
+      );
+
+      return updatedCode;
     };
 
     const updateStarknetRsParams = (currentParamsObj: {


### PR DESCRIPTION
Implemented starknet.go support for write endpoints. Closes #10. Implemented:
- [x] `starknet_addInvokeTransaction`
- [x] `starknet_addDeployAccountTransaction`

Result:

![Screenshot from 2024-02-19 20-23-47](https://github.com/NethermindEth/rpc-request-builder/assets/76250660/7fc4bd96-8647-4108-8653-e05e89b135a2)
