### PR TITLE
Implemented starknet.go support for transaction endpoints

### DIFF
--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -391,13 +391,12 @@ func main() {
     console.log(transactionStatus);
 });
     `,
-    starknetGo: `${STARKNET_GO_PREFIX}ctx := context.Background()
-    txStatus, err := provider.GetTransactionStatus(ctx, "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
+    starknetGo: `${STARKNET_GO_PREFIX}result, err := provider.GetTransactionStatus(context.Background(), "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
      if err != nil {
           log.Fatal(err) 
       }
       
-     fmt.Println(txStatus)
+     fmt.Println(result)
   }
   `,
     starknetRs: ``,
@@ -413,13 +412,12 @@ func main() {
   console.log(transaction);
 });
     `,
-    starknetGo: `${STARKNET_GO_PREFIX}ctx := context.Background()
-    txStatus, err := provider.GetTransactionByHash(ctx, "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
+    starknetGo: `${STARKNET_GO_PREFIX}result, err := provider.GetTransactionByHash(context.Background(), "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
      if err != nil {
           log.Fatal(err) 
       }
       
-     fmt.Println(txStatus)
+     fmt.Println(result)
   }
     `,
     starknetRs: ``,
@@ -439,7 +437,14 @@ func main() {
   console.log(transaction);
 });
     `,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}result, err := provider.GetTransactionByHash(context.Background(), "latest", 0)
+     if err != nil {
+          log.Fatal(err) 
+      }
+      
+     fmt.Println(result)
+  }
+    `,
     starknetRs: ``,
   },
 
@@ -453,7 +458,14 @@ func main() {
   console.log(transactionReceipt);
 });
     `,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}result, err := provider.GetTransactionReceipt(context.Background(), "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
+    if err != nil {
+         log.Fatal(err) 
+     }
+     
+    fmt.Println(result)
+ }
+    `,
     starknetRs: ``,
   },
 
@@ -544,7 +556,14 @@ func main() {
     console.log(transactionCount);
 });
     `,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}result, err := provider.GetBlockTransactionCount(context.Background(), "latest")
+    if err != nil {
+         log.Fatal(err) 
+     }
+     
+    fmt.Println(result)
+ }
+    `,
     starknetRs: ``,
   },
 
@@ -735,7 +754,37 @@ func main() {
       },
     },
     starknetJs: ``,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}result, err := provider.GetTransactionStatus(context.Background(),
+		map[string]interface{}{
+			"from_block": blockID,
+			"to_block":   blockID,
+			"address":    contractAddress,
+			"keys": map[string]interface{}{
+				"placeholder": [][]string{
+					{
+						"0x1001e85047571380eed1d7e1cc5a9af6a707b3d65789bb1702c7d680e5e87e",
+					},
+				},
+				"description": "The key to the storage value for the given contract",
+				"type":        "array",
+			},
+			"continuation_token": map[string]interface{}{
+				"placeholder": "",
+				"description": "The token returned from the previous query. If no token is provided the first page is returned",
+			},
+			"chunk_size": map[string]interface{}{
+				"placeholder": 2,
+				"description": "The number of events to return",
+			},
+		})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result)
+  }
+    `,
     starknetRs: ``,
   },
 

--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -391,7 +391,15 @@ func main() {
     console.log(transactionStatus);
 });
     `,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}ctx := context.Background()
+    txStatus, err := provider.GetTransactionStatus(ctx, "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
+     if err != nil {
+          log.Fatal(err) 
+      }
+      
+     fmt.Println(txStatus)
+  }
+  `,
     starknetRs: ``,
   },
 

--- a/src/api/rpcspec/methods.ts
+++ b/src/api/rpcspec/methods.ts
@@ -413,7 +413,15 @@ func main() {
   console.log(transaction);
 });
     `,
-    starknetGo: ``,
+    starknetGo: `${STARKNET_GO_PREFIX}ctx := context.Background()
+    txStatus, err := provider.GetTransactionByHash(ctx, "0x7641514f46a77013e80215cdce2e55d5aca49c13428b885c7ecb9d3ddb4ab11")
+     if err != nil {
+          log.Fatal(err) 
+      }
+      
+     fmt.Println(txStatus)
+  }
+    `,
     starknetRs: ``,
   },
 


### PR DESCRIPTION
Added autogenerated starknet.go support for the following endpoints.

starknet_getTransactionStatus
starknet_getTransactionByHash
starknet_getTransactionByBlockIdAndIndex
starknet_getTransactionReceipt
starknet_getBlockTransactionCount
starknet_getEvents

closes issue #7 